### PR TITLE
Support building Parallels boxes using packer 0.7.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,5 +2,6 @@
 # If you're submitting a patch, please add your name here in alphabetical order as part of the patch.
 #
 Mischa Taylor <mischa@misheska.com>
+Rickard von Essen <rickard.von.essen@gmail.com>
 Ross Smith II <ross@smithii.com>
 Ronen Narkis <narkisr@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -34,17 +34,20 @@ ifeq ($(CM),nocm)
 else
 	BOX_SUFFIX := -$(CM)$(CM_VERSION).box
 endif
-BUILDER_TYPES := vmware virtualbox
+BUILDER_TYPES := vmware virtualbox parallels
 TEMPLATE_FILENAMES := $(wildcard *.json)
 BOX_FILENAMES := $(TEMPLATE_FILENAMES:.json=$(BOX_SUFFIX))
 BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), box/$(builder)/$(box_filename)))
 TEST_BOX_FILES := $(foreach builder, $(BUILDER_TYPES), $(foreach box_filename, $(BOX_FILENAMES), test-box/$(builder)/$(box_filename)))
 VMWARE_BOX_DIR := box/vmware
 VIRTUALBOX_BOX_DIR := box/virtualbox
+PARALLELS_BOX_DIR := box/parallels
 VMWARE_OUTPUT := output-vmware-iso
 VIRTUALBOX_OUTPUT := output-virtualbox-iso
+PARALLELS_OUTPUT := output-parallels-iso
 VMWARE_BUILDER := vmware-iso
 VIRTUALBOX_BUILDER := virtualbox-iso
+PARALLELS_BUILDER := parallels-iso
 CURRENT_DIR = $(shell pwd)
 SOURCES := $(wildcard script/*.sh) $(http/*.cfg)
 
@@ -58,9 +61,9 @@ test: $(TEST_BOX_FILES)
 # Target shortcuts
 define SHORTCUT
 
-$(1): vmware/$(1) virtualbox/$(1)
+$(1): vmware/$(1) virtualbox/$(1) parallels/$(1)
 
-test-$(1): test-vmware/$(1) test-virtualbox/$(1)
+test-$(1): test-vmware/$(1) test-virtualbox/$(1) test-parallels/$(1)
 
 vmware/$(1): $(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
@@ -69,6 +72,10 @@ test-vmware/$(1): test-$(VMWARE_BOX_DIR)/$(1)$(BOX_SUFFIX)
 virtualbox/$(1): $(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 test-virtualbox/$(1): test-$(VIRTUALBOX_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+parallels/$(1): $(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
+
+test-parallels/$(1): test-$(PARALLELS_BOX_DIR)/$(1)$(BOX_SUFFIX)
 
 endef
 
@@ -140,7 +147,7 @@ $(VMWARE_BOX_DIR)/debian609-i386$(BOX_SUFFIX): debian609-i386.json $(SOURCES)
 #	rm -rf output-virtualbox-iso
 #	mkdir -p $(VIRTUALBOX_BOX_DIR)
 #	packer build -only=virtualbox-iso $(PACKER_VARS) $<
-	
+
 $(VIRTUALBOX_BOX_DIR)/debian76$(BOX_SUFFIX): debian76.json $(SOURCES)
 	rm -rf $(VIRTUALBOX_OUTPUT)
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
@@ -191,8 +198,66 @@ $(VIRTUALBOX_BOX_DIR)/debian609-i386$(BOX_SUFFIX): debian609-i386.json $(SOURCES
 	mkdir -p $(VIRTUALBOX_BOX_DIR)
 	packer build -only=$(VIRTUALBOX_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN609_I386)" $<
 
+# Generic rule - not used currently
+#$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): %.json
+#	cd $(dir $<)
+#	rm -rf output-virtualbox-iso
+#	mkdir -p $(PARALLELS_BOX_DIR)
+#	packer build -only=parallels-iso $(PACKER_VARS) $<
+
+$(PARALLELS_BOX_DIR)/debian76$(BOX_SUFFIX): debian76.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN76_AMD64)" $<
+
+$(PARALLELS_BOX_DIR)/debian75$(BOX_SUFFIX): debian75.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN75_AMD64)" $<
+
+$(PARALLELS_BOX_DIR)/debian74$(BOX_SUFFIX): debian74.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN74_AMD64)" $<
+
+$(PARALLELS_BOX_DIR)/debian6010$(BOX_SUFFIX): debian6010.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN6010_AMD64)" $<
+
+$(PARALLELS_BOX_DIR)/debian609$(BOX_SUFFIX): debian609.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN609_AMD64)" $<
+
+$(PARALLELS_BOX_DIR)/debian76-i386$(BOX_SUFFIX): debian76-i386.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN76_I386)" $<
+
+$(PARALLELS_BOX_DIR)/debian75-i386$(BOX_SUFFIX): debian75-i386.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN75_I386)" $<
+
+$(PARALLELS_BOX_DIR)/debian74-i386$(BOX_SUFFIX): debian74-i386.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN74_I386)" $<
+
+$(PARALLELS_BOX_DIR)/debian6010-i386$(BOX_SUFFIX): debian6010-i386.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN6010_I386)" $<
+
+$(PARALLELS_BOX_DIR)/debian609-i386$(BOX_SUFFIX): debian609-i386.json $(SOURCES)
+	rm -rf $(PARALLELS_OUTPUT)
+	mkdir -p $(PARALLELS_BOX_DIR)
+	packer build -only=$(PARALLELS_BUILDER) $(PACKER_VARS) -var "iso_url=$(DEBIAN609_I386)" $<
+
+
 list:
-	@echo "Prepend 'vmware/' or 'virtualbox/' to build a particular target:"
+	@echo "Prepend 'vmware/', 'virtualbox/', or 'parallels/' to build a particular target:"
 	@echo "  make vmware/debian76"
 	@echo ""
 	@echo "Targets;"
@@ -207,7 +272,7 @@ validate:
 	done
 
 clean: clean-builders clean-output clean-packer-cache
-		
+
 clean-builders:
 	@for builder in $(BUILDER_TYPES) ; do \
 		if test -d box/$$builder ; then \
@@ -215,25 +280,31 @@ clean-builders:
 			find box/$$builder -maxdepth 1 -type f -name "*.box" ! -name .gitignore -exec rm '{}' \; ; \
 		fi ; \
 	done
-	
+
 clean-output:
 	@for builder in $(BUILDER_TYPES) ; do \
 		echo Deleting output-$$builder-iso ; \
 		echo rm -rf output-$$builder-iso ; \
 	done
-	
+
 clean-packer-cache:
 	echo Deleting packer_cache
 	rm -rf packer_cache
 
 test-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/test-box.sh $< vmware_desktop vmware_fusion $(CURRENT_DIR)/test/*_spec.rb
-	
+
 test-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/test-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb
-	
+
+test-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
+	bin/test-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb
+
 ssh-$(VMWARE_BOX_DIR)/%$(BOX_SUFFIX): $(VMWARE_BOX_DIR)/%$(BOX_SUFFIX)
 	bin/ssh-box.sh $< vmware_desktop vmware_fusion $(CURRENT_DIR)/test/*_spec.rb
-	
+
 ssh-$(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX): $(VIRTUALBOX_BOX_DIR)/%$(BOX_SUFFIX)
-	bin/ssh-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb	
+	bin/ssh-box.sh $< virtualbox virtualbox $(CURRENT_DIR)/test/*_spec.rb
+
+ssh-$(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX): $(PARALLELS_BOX_DIR)/%$(BOX_SUFFIX)
+	bin/ssh-box.sh $< parallels parallels $(CURRENT_DIR)/test/*_spec.rb

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Packer templates for Debian
-[![Build Status](https://box-cutter.ci.cloudbees.com/buildStatus/icon?job=debian-vm)](https://box-cutter.ci.cloudbees.com/job/debian-vm/) 
+[![Build Status](https://box-cutter.ci.cloudbees.com/buildStatus/icon?job=debian-vm)](https://box-cutter.ci.cloudbees.com/job/debian-vm/)
 
 ### Overview
 
@@ -26,11 +26,12 @@ using Packer.
 
 ## Building the Vagrant boxes
 
-To build all the boxes, you will need both VirtualBox and VMware Fusion installed.
+To build all the boxes, you will need both VirtualBox, VMware Fusion, and
+Parallels Desktop for Mac installed.
 
 A GNU Make `Makefile` drives the process via the following targets:
 
-    make        # Build all the box types (VirtualBox & VMware)
+    make        # Build all the box types (VirtualBox, VMware & Parallels)
     make test   # Run tests against all the boxes
     make list   # Print out individual targets
     make clean  # Clean up build detritus
@@ -53,7 +54,7 @@ The tests are written in [Serverspec](http://serverspec.org) and require the
 `vagrant-serverspec` plugin to be installed with:
 
     vagrant plugin install vagrant-serverspec
-    
+
 The `Makefile` has individual targets for each box type with the prefix
 `test-*` should you wish to run tests individually for each box.
 
@@ -63,7 +64,7 @@ do exploratory testing.  For example, to do exploratory testing
 on the VirtualBox training environmnet, run the following command:
 
     make ssh-box/virtualbox/debian76-nocm.box
-    
+
 Upon logout `make ssh-*` will automatically de-register the box as well.
 
 ### Makefile.local override

--- a/debian6010-i386.json
+++ b/debian6010-i386.json
@@ -87,6 +87,43 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian6010-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install <wait>",
+      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+      "debian-installer=en_US <wait>",
+      "auto <wait>",
+      "locale=en_US <wait>",
+      "kbd-chooser/method=us <wait>",
+      "keyboard-configuration/xkb-keymap=us <wait>",
+      "netcfg/get_hostname={{ .Name }} <wait>",
+      "netcfg/get_domain=vagrantup.com <wait>",
+      "fb=false <wait>",
+      "debconf/frontend=noninteractive <wait>",
+      "console-setup/ask_detect=false <wait>",
+      "console-keymaps-at/keymap=us <wait>",
+      "<enter><wait>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian6010.json
+++ b/debian6010.json
@@ -87,6 +87,43 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian6010",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install <wait>",
+      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+      "debian-installer=en_US <wait>",
+      "auto <wait>",
+      "locale=en_US <wait>",
+      "kbd-chooser/method=us <wait>",
+      "keyboard-configuration/xkb-keymap=us <wait>",
+      "netcfg/get_hostname={{ .Name }} <wait>",
+      "netcfg/get_domain=vagrantup.com <wait>",
+      "fb=false <wait>",
+      "debconf/frontend=noninteractive <wait>",
+      "console-setup/ask_detect=false <wait>",
+      "console-keymaps-at/keymap=us <wait>",
+      "<enter><wait>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian609-i386.json
+++ b/debian609-i386.json
@@ -87,6 +87,43 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian609-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install <wait>",
+      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+      "debian-installer=en_US <wait>",
+      "auto <wait>",
+      "locale=en_US <wait>",
+      "kbd-chooser/method=us <wait>",
+      "keyboard-configuration/xkb-keymap=us <wait>",
+      "netcfg/get_hostname={{ .Name }} <wait>",
+      "netcfg/get_domain=vagrantup.com <wait>",
+      "fb=false <wait>",
+      "debconf/frontend=noninteractive <wait>",
+      "console-setup/ask_detect=false <wait>",
+      "console-keymaps-at/keymap=us <wait>",
+      "<enter><wait>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian609.json
+++ b/debian609.json
@@ -87,6 +87,43 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian609",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{ user `iso_url` }}",
+    "iso_checksum": "{{ user `iso_checksum` }}",
+    "iso_checksum_type": "sha1",
+    "guest_os_type": "debian",
+    "parallels_tools_flavor": "lin",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install <wait>",
+      "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+      "debian-installer=en_US <wait>",
+      "auto <wait>",
+      "locale=en_US <wait>",
+      "kbd-chooser/method=us <wait>",
+      "keyboard-configuration/xkb-keymap=us <wait>",
+      "netcfg/get_hostname={{ .Name }} <wait>",
+      "netcfg/get_domain=vagrantup.com <wait>",
+      "fb=false <wait>",
+      "debconf/frontend=noninteractive <wait>",
+      "console-setup/ask_detect=false <wait>",
+      "console-keymaps-at/keymap=us <wait>",
+      "<enter><wait>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian74-i386.json
+++ b/debian74-i386.json
@@ -78,6 +78,38 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian74-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "guest_os_type": "debian",
+    "parallels_tools_flavor": "lin",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install",
+      " auto",
+      " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+      " debian-installer=en_US",
+      " locale=en_US",
+      " keymap=us",
+      " netcfg/get_hostname=vagrant",
+      " netcfg/get_domain=vm ",
+      "<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian74.json
+++ b/debian74.json
@@ -78,6 +78,38 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian74",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install",
+      " auto",
+      " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+      " debian-installer=en_US",
+      " locale=en_US",
+      " keymap=us",
+      " netcfg/get_hostname=vagrant",
+      " netcfg/get_domain=vm ",
+      "<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian75-i386.json
+++ b/debian75-i386.json
@@ -78,6 +78,38 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian75-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install",
+      " auto",
+      " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+      " debian-installer=en_US",
+      " locale=en_US",
+      " keymap=us",
+      " netcfg/get_hostname=vagrant",
+      " netcfg/get_domain=vm ",
+      "<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian75.json
+++ b/debian75.json
@@ -78,6 +78,38 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian75",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install",
+      " auto",
+      " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+      " debian-installer=en_US",
+      " locale=en_US",
+      " keymap=us",
+      " netcfg/get_hostname=vagrant",
+      " netcfg/get_domain=vm ",
+      "<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian76-i386.json
+++ b/debian76-i386.json
@@ -76,6 +76,38 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian76-i386",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "parallels_tools_flavor": "lin",
+    "guest_os_type": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install",
+      " auto",
+      " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+      " debian-installer=en_US",
+      " locale=en_US",
+      " keymap=us",
+      " netcfg/get_hostname=vagrant",
+      " netcfg/get_domain=vm ",
+      "<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/debian76.json
+++ b/debian76.json
@@ -78,6 +78,38 @@
       ["modifyvm", "{{.Name}}", "--memory", "512"],
       ["modifyvm", "{{.Name}}", "--cpus", "1"]
     ]
+  },
+  {
+    "vm_name": "debian76",
+    "type": "parallels-iso",
+    "http_directory": "http",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "parallels_tools_flavor": "lin",
+    "guest_os_flavor": "debian",
+    "prlctl_version_file": ".prlctl_version",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_wait_timeout": "10000s",
+    "boot_command": [
+      "<esc><wait>",
+      "install",
+      " auto",
+      " url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg",
+      " debian-installer=en_US",
+      " locale=en_US",
+      " keymap=us",
+      " netcfg/get_hostname=vagrant",
+      " netcfg/get_domain=vm ",
+      "<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant'|sudo -S shutdown -h now",
+    "disk_size": 10140,
+    "prlctl": [
+      ["set", "{{.Name}}", "--memsize", "512"],
+      ["set", "{{.Name}}", "--cpus", "1"]
+    ]
   }],
   "provisioners": [{
     "type": "shell",

--- a/script/vmtool.sh
+++ b/script/vmtool.sh
@@ -31,3 +31,13 @@ if [[ $PACKER_BUILDER_TYPE =~ virtualbox ]]; then
         ln -s /opt/VBoxGuestAdditions-4.3.10/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions
     fi
 fi
+
+if [[ $PACKER_BUILDER_TYPE =~ parallels ]]; then
+    echo "==> Installing Parallels tools"
+
+    mount -o loop /home/vagrant/prl-tools-lin.iso /mnt
+    /mnt/install --install-unattended-with-deps
+    umount /mnt
+    rm -rf /home/vagrant/prl-tools-lin.iso
+    rm -f /home/vagrant/.prlctl_version
+fi


### PR DESCRIPTION
Support building vagrant boxes for Parallels Desktop for Mac.

Requires Parallels Desktop 9+ and packer v 0.7.0.
