### PR TITLE
Fixing Puppet installation

### DIFF
--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -67,11 +67,10 @@ install_salt()
 install_puppet()
 {
     echo "==> Installing Puppet"
-    . /etc/lsb-release
-
-    DEB_NAME=puppetlabs-release-${DISTRIB_CODENAME}.deb
+    DEB_NAME=puppetlabs-release-$(/usr/bin/lsb_release -cs).deb
     wget http://apt.puppetlabs.com/${DEB_NAME}
     dpkg -i ${DEB_NAME}
+    apt-get update
     if [[ ${CM_VERSION:-} == 'latest' ]]; then
       echo "Installing latest Puppet version"
       apt-get install -y puppet


### PR DESCRIPTION
To start I used the following command:

```
make virtualbox/debian77
```

Further I used a Makefile.local to install Puppet as my CM:

```
CM := puppet
CM_VERSION := 3.7.3-1puppetlabs1
UPDATE := true
HEADLESS := true
```

and I got the following output:

```
==> virtualbox-iso: Provisioning with shell script: script/cmtool.sh
    virtualbox-iso: ==> Installing Puppet
    virtualbox-iso: /tmp/script.sh: line 70: /etc/lsb-release: No such file or directory
    virtualbox-iso: --2014-12-02 07:20:54--  http://apt.puppetlabs.com/puppetlabs-release-.deb
    virtualbox-iso: Resolving apt.puppetlabs.com (apt.puppetlabs.com)... 198.58.114.168, 2600:3c00::f03c:91ff:fe69:6bf0
    virtualbox-iso: Connecting to apt.puppetlabs.com (apt.puppetlabs.com)|198.58.114.168|:80... connected.
    virtualbox-iso: HTTP request sent, awaiting response... 404 Not Found
    virtualbox-iso: 2014-12-02 07:20:54 ERROR 404: Not Found.
    virtualbox-iso:
    virtualbox-iso: dpkg: error processing puppetlabs-release-.deb (--install):
    virtualbox-iso: cannot access archive: No such file or directory
    virtualbox-iso: Errors were encountered while processing:
    virtualbox-iso: puppetlabs-release-.deb
    virtualbox-iso: Installing Puppet version 3.7.3-1puppetlabs1
    virtualbox-iso: Reading package lists... Done
    virtualbox-iso: Building dependency tree
    virtualbox-iso: Reading state information... Done
    virtualbox-iso: E: Version '3.7.3-1puppetlabs1' for 'puppet-common' was not found
    virtualbox-iso: E: Version '3.7.3-1puppetlabs1' for 'puppet' was not found
```

Probably there's an error occuring resolving the variable DEB_NAME. `/etc/lsb-release` is not available on Debian that's why the variable stays empty and dpkg is trying to install a package which doesn't exist.
To conclude you should do an update, too.
