### PR TITLE
Fixed CM installation

### DIFF
--- a/script/minimize.sh
+++ b/script/minimize.sh
@@ -17,18 +17,23 @@ echo "==> Removing documentation"
 dpkg --list | awk '{ print $2 }' | grep -- '-doc$' | xargs apt-get -y purge
 echo "==> Removing development tools"
 #dpkg --list | grep -i compiler | awk '{ print $2 }' | xargs apt-get -y purge
-#apt-get -y purge cpp gcc g++ 
+#apt-get -y purge cpp gcc g++
 apt-get -y purge build-essential
-echo "==> Removing default system Ruby"
-apt-get -y purge ruby ri doc
-echo "==> Removing default system Python"
-apt-get -y purge python-dbus libnl1 python-smartpm python-twisted-core libiw30 python-twisted-bin libdbus-glib-1-2 python-pexpect python-pycurl python-serial python-gobject python-pam python-openssl libffi5
 echo "==> Removing X11 libraries"
 apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6
 echo "==> Removing obsolete networking components"
 apt-get -y purge ppp pppconfig pppoeconf
 echo "==> Removing other oddities"
 apt-get -y purge popularity-contest installation-report wireless-tools wpasupplicant
+
+# Only remove ruby if not required by the CM
+if ! [[ ${CM} == 'puppet' ]]; then
+  echo "==> Removing default system Ruby"
+  apt-get -y purge ruby ri doc libffi5
+fi
+
+echo "==> Removing default system Python"
+apt-get -y purge python-dbus libnl1 python-smartpm python-twisted-core libiw30 python-twisted-bin libdbus-glib-1-2 python-pexpect python-pycurl python-serial python-gobject python-pam python-openssl
 
 # Clean up the apt cache
 apt-get -y autoremove --purge


### PR DESCRIPTION
If Puppet is set as CM and Ruby gets uninstalled, Puppet gets removed too. Fixing #10 

```
==> virtualbox-iso: Provisioning with shell script: script/minimize.sh
    virtualbox-iso: ==> Installed packages before cleanup
[...]
    virtualbox-iso: puppet                       install
    virtualbox-iso: puppet-common        install
[...]
    virtualbox-iso: ==> Removing default system Ruby
[...]
    virtualbox-iso: The following packages will be REMOVED:
    virtualbox-iso: libaugeas-ruby* libaugeas-ruby1.9.1*
    virtualbox-iso: libffi5* libruby1.9.1* puppet*
    virtualbox-iso: puppet-common* ruby* ruby1.9.1*
[...]
    virtualbox-iso: Removing puppet ...
[ ok irtualbox-iso: [....] Stopping puppet agent.
    virtualbox-iso: Purging configuration files for puppet ...
    virtualbox-iso: Removing puppet-common ...
    virtualbox-iso: Purging configuration files for puppet-common ...
    virtualbox-iso: Removing libaugeas-ruby ...
    virtualbox-iso: Removing libaugeas-ruby1.9.1 ...
    virtualbox-iso: Removing ruby ...
    virtualbox-iso: Removing ruby1.9.1 ...
[...]
    virtualbox-iso: ==> Removing man pages
    virtualbox-iso: ==> Removing APT files
    virtualbox-iso: ==> Removing anything in /usr/src
    virtualbox-iso: ==> Removing any docs
    virtualbox-iso: ==> Removing caches
```
